### PR TITLE
Passed detected device during instantiation of CellTypeModel

### DIFF
--- a/astir/astir.py
+++ b/astir/astir.py
@@ -154,6 +154,7 @@ class Astir:
                 self._type_dset,
                 int(seed),
                 self._dtype,
+                self._device,
             )
             for seed in seeds
         ]


### PR DESCRIPTION
Passed detected device during instantiation of CellTypeModel objects in astir.py.

Caleb
